### PR TITLE
refactor(yane-core)!: Added NES struct and changed Arc<Mutex<_>> to Rc<RefCell<_>>

### DIFF
--- a/.idea/yane.iml
+++ b/.idea/yane.iml
@@ -4,6 +4,9 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/yane-core/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/yane-desktop/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/yane-web/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "cfg-if"
@@ -68,9 +68,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -181,19 +181,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.40"
+name = "once_cell"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -380,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -391,15 +397,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -407,13 +413,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -422,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -432,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -445,15 +451,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/yane-core/src/cartridge.rs
+++ b/yane-core/src/cartridge.rs
@@ -1,7 +1,7 @@
 use crate::mapper::Mapper;
 use crate::mapper_0::Mapper0;
 use std::fs::File;
-use std::io::{Read, BufReader};
+use std::io::Read;
 
 pub struct Cartridge {
     prg_memory: Vec<u8>,

--- a/yane-core/src/cpu/tests/bitwise_instructions/and_instruction.rs
+++ b/yane-core/src/cpu/tests/bitwise_instructions/and_instruction.rs
@@ -1,6 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
+use crate::CPU;
 #[test]
 fn immediate_instruction() {
     let mut rom = [0u8; 0x7fff];
@@ -12,9 +10,7 @@ fn immediate_instruction() {
     rom[2] = 0x29;
     rom[3] = 7;
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     cpu.exec();
@@ -32,10 +28,7 @@ fn zeropage() {
     rom[2] = 0x25;
     rom[3] = 61;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.write(61, 7);
     cpu.init();
     cpu.exec();
@@ -55,9 +48,7 @@ fn zeropage_x() {
     rom[3] = 61;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(62, 7);
     cpu.init();
@@ -79,10 +70,7 @@ fn abs() {
     rom[3] = 0x10;
     rom[4] = 0x10;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x1010, 7);
     cpu.init();
     cpu.exec();
@@ -104,9 +92,7 @@ fn abs_x() {
     rom[4] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(0x1011, 7);
     cpu.init();
@@ -128,10 +114,7 @@ fn abs_y() {
     rom[3] = 0x10;
     rom[4] = 0x10;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 1;
     cpu.write(0x1011, 7);
     cpu.init();
@@ -152,10 +135,7 @@ fn indirect_y() {
     rom[2] = 0x31;
     rom[3] = 0x11;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 1;
     cpu.write(0x11, 0x11);
     cpu.write(0x12, 0x12);
@@ -178,10 +158,7 @@ fn indirect_x() {
     rom[2] = 0x21;
     rom[3] = 0x11;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(0x12, 0x11);
     cpu.write(0x13, 0x12);

--- a/yane-core/src/cpu/tests/bitwise_instructions/asl_instruction.rs
+++ b/yane-core/src/cpu/tests/bitwise_instructions/asl_instruction.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn accumulator() {
     let mut rom = [0u8; 0x7fff];
 
@@ -9,10 +6,7 @@ fn accumulator() {
     rom[0x3FFD] = 0x80;
     rom[0] = 0x0A;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.a = 3;
     cpu.init();
     cpu.exec();
@@ -31,14 +25,11 @@ fn zeropage() {
     rom[0] = 0x06;
     rom[1] = 0;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[0] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
+    cpu.memory.borrow_mut().ram[0] = 0x3;
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[0], 3 << 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[0], 3 << 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, false);
@@ -54,14 +45,12 @@ fn zeropage_x() {
     rom[1] = 0;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[1] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[1] = 0x3;
     cpu.registers.x = 1;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[1], 3 << 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[1], 3 << 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, false);
@@ -77,14 +66,11 @@ fn abs() {
     rom[1] = 0x11;
     rom[2] = 0x5;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[0x511] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[0x511] = 0x3;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[0x511], 3 << 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[0x511], 3 << 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, false);
@@ -100,15 +86,12 @@ fn abs_x() {
     rom[1] = 0x11;
     rom[2] = 0x5;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[0x512] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[0x512] = 0x3;
     cpu.registers.x = 1;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[0x512], 3 << 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[0x512], 3 << 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, false);

--- a/yane-core/src/cpu/tests/bitwise_instructions/bit.rs
+++ b/yane-core/src/cpu/tests/bitwise_instructions/bit.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bit_zp() {
     let mut rom = [0u8; 0x7fff];
@@ -11,10 +8,7 @@ fn bit_zp() {
     rom[0] = 0x24;
     rom[1] = 0x10;
 
-    
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.a = 0xF;
     cpu.write(0x0010, 0b11000000);
     cpu.init();
@@ -30,15 +24,10 @@ fn bit_abs() {
 
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
-
     rom[0] = 0x2C;
     rom[1] = 0x10;
     rom[2] = 0x10;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.a = 0xF;
     cpu.write(0x1010, 0b11000000);
     cpu.init();

--- a/yane-core/src/cpu/tests/bitwise_instructions/lsr_instruction.rs
+++ b/yane-core/src/cpu/tests/bitwise_instructions/lsr_instruction.rs
@@ -1,6 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
+use crate::CPU;
 
 #[test]
 fn accumulator() {
@@ -10,10 +8,7 @@ fn accumulator() {
     rom[0x3FFD] = 0x80;
     rom[0] = 0x4A;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.a = 3;
     cpu.init();
     cpu.exec();
@@ -33,13 +28,11 @@ fn zeropage() {
     rom[1] = 0;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[0] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[0] = 0x3;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[0], 3 >> 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[0], 3 >> 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, true);
@@ -55,14 +48,12 @@ fn zeropage_x() {
     rom[1] = 0;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[1] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[1] = 0x3;
     cpu.registers.x = 1;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[1], 3 >> 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[1], 3 >> 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, true);
@@ -79,13 +70,11 @@ fn abs() {
     rom[2] = 0x5;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[0x511] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[0x511] = 0x3;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[0x511], 3 >> 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[0x511], 3 >> 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, true);
@@ -101,15 +90,12 @@ fn abs_x() {
     rom[1] = 0x11;
     rom[2] = 0x05;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
-    Rc::get_mut(&mut cpu.memory).unwrap().ram[0x512] = 0x3;
+    let mut cpu = CPU::from_rom(&rom);
+    cpu.memory.borrow_mut().ram[0x512] = 0x3;
     cpu.registers.x = 1;
     cpu.init();
     cpu.exec();
-    assert_eq!(Rc::get_mut(&mut cpu.memory).unwrap().ram[0x512], 3 >> 1);
+    assert_eq!(cpu.memory.borrow_mut().ram[0x512], 3 >> 1);
     assert_eq!(cpu.registers.negative, false);
     assert_eq!(cpu.registers.zero, false);
     assert_eq!(cpu.registers.carry, true);

--- a/yane-core/src/cpu/tests/bitwise_instructions/ora_instruction.rs
+++ b/yane-core/src/cpu/tests/bitwise_instructions/ora_instruction.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn immediate_instruction() {
     let mut rom = [0u8; 0x7fff];
 
@@ -12,10 +9,7 @@ fn immediate_instruction() {
     rom[2] = 0x09;
     rom[3] = 7;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     cpu.exec();
@@ -34,9 +28,7 @@ fn zeropage() {
     rom[3] = 61;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(60, 10);
     cpu.write(61, 7);
     cpu.init();
@@ -57,9 +49,7 @@ fn zeropage_x() {
     rom[3] = 61;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(61, 10);
     cpu.write(62, 7);
@@ -84,9 +74,7 @@ fn abs() {
     rom[5] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x1010, 10);
     cpu.write(0x1011, 7);
     cpu.init();
@@ -109,9 +97,7 @@ fn abs_x() {
     rom[5] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(0x1011, 10);
     cpu.write(0x1012, 7);
@@ -136,9 +122,7 @@ fn abs_y() {
     rom[5] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 1;
     cpu.write(0x1011, 10);
     cpu.write(0x1012, 7);
@@ -161,9 +145,7 @@ fn indirect_y() {
     rom[3] = 0x11;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 1;
     cpu.write(0x11, 0x11);
     cpu.write(0x12, 0x12);
@@ -188,9 +170,7 @@ fn indirect_x() {
     rom[3] = 0x11;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(0x12, 0x11);
     cpu.write(0x13, 0x12);

--- a/yane-core/src/cpu/tests/branching_instructions/bcc.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bcc.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bcc_jumps_when_carry_is_false() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bcc_jumps_when_carry_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = false;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bcc_does_not_jump_when_carry_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = true;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/bcs.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bcs.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bcs_jumps_when_carry_is_true() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bcs_jumps_when_carry_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = true;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bcs_does_not_jump_when_carry_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = false;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/beq.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/beq.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn beq_jumps_when_zero_is_true() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn beq_jumps_when_zero_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.zero = true;
     cpu.exec();
@@ -29,9 +24,7 @@ fn beq_does_not_jump_when_zero_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.zero = false;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/bmi.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bmi.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bmi_jumps_when_negative_is_true() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bmi_jumps_when_negative_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.negative = true;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bmi_does_not_jump_when_negative_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.negative = false;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/bne.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bne.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bne_jumps_when_zero_is_false() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bne_jumps_when_zero_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.zero = false;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bne_does_not_jump_when_zero_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.zero = true;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/bpl.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bpl.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bpl_jumps_when_negative_is_false() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bpl_jumps_when_negative_is_false() {
     rom[1] = 3;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.negative = false;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bpl_does_not_jump_when_negative_is_true() {
     rom[1] = 3;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.negative = true;
     cpu.exec();
@@ -47,9 +40,7 @@ fn bpl_works_with_negative_relative_addresses() {
     rom[1] = -6i8 as u8;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.negative = false;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/bvc.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bvc.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bvc_jumps_when_overflow_is_false() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bvc_jumps_when_overflow_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.overflow = false;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bvc_does_not_jump_when_overflow_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.overflow = true;
     cpu.exec();

--- a/yane-core/src/cpu/tests/branching_instructions/bvs.rs
+++ b/yane-core/src/cpu/tests/branching_instructions/bvs.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn bvs_jumps_when_overflow_is_true() {
     let mut rom = [0u8; 0x7fff];
@@ -11,9 +8,7 @@ fn bvs_jumps_when_overflow_is_true() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.overflow = true;
     cpu.exec();
@@ -29,9 +24,7 @@ fn bvs_does_not_jump_when_overflow_is_false() {
     rom[1] = 4;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.overflow = false;
     cpu.exec();

--- a/yane-core/src/cpu/tests/clear_and_set.rs
+++ b/yane-core/src/cpu/tests/clear_and_set.rs
@@ -1,18 +1,10 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn clc() {
     let mut rom = [0u8; 0x7fff];
-
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x18;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = true;
     cpu.exec();
@@ -27,9 +19,7 @@ fn sec() {
     rom[0] = 0x38;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = false;
     cpu.exec();
@@ -44,9 +34,7 @@ fn clv() {
     rom[0] = 0xB8;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.overflow = true;
     cpu.exec();

--- a/yane-core/src/cpu/tests/interrupts.rs
+++ b/yane-core/src/cpu/tests/interrupts.rs
@@ -1,19 +1,11 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn cli_enables_interrupts() {
     let mut rom = [0u8; 0x7fff];
-
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x58;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.interrupt_disable = true;
     cpu.exec();
@@ -27,11 +19,7 @@ fn sei_disables_interrupts() {
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x78;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.interrupt_disable = false;
     cpu.exec();

--- a/yane-core/src/cpu/tests/load_instructions/lda_instruction.rs
+++ b/yane-core/src/cpu/tests/load_instructions/lda_instruction.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn immediate() {
     let mut rom = [0u8; 0x7fff];
 
@@ -11,9 +8,7 @@ fn immediate() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     assert_eq!(cpu.registers.a, 0x10);
@@ -29,9 +24,7 @@ fn zero_page() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x10, 0x4);
     cpu.init();
     cpu.exec();
@@ -48,9 +41,7 @@ fn zero_page_x() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 2;
     cpu.write(0x12, 0x4);
     cpu.init();
@@ -69,9 +60,7 @@ fn abs() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x1000, 0x4);
     cpu.init();
     cpu.exec();
@@ -89,9 +78,7 @@ fn abs_x() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 2;
     cpu.write(0x1002, 0x4);
     cpu.init();
@@ -110,9 +97,7 @@ fn abs_y() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 2;
     cpu.write(0x1002, 0x4);
     cpu.init();
@@ -130,9 +115,7 @@ fn indirect_x() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 2;
     cpu.write(0x12, 0x00);
     cpu.write(0x13, 0x04);
@@ -152,9 +135,7 @@ fn indirect_y() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 2;
     cpu.write(0x10, 0x00);
     cpu.write(0x11, 0x04);

--- a/yane-core/src/cpu/tests/load_instructions/ldx_instruction.rs
+++ b/yane-core/src/cpu/tests/load_instructions/ldx_instruction.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn immediate() {
     let mut rom = [0u8; 0x7fff];
 
@@ -11,9 +8,7 @@ fn immediate() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     assert_eq!(cpu.registers.x, 0x10);
@@ -29,9 +24,7 @@ fn zero_page() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x10, 0x4);
     cpu.init();
     cpu.exec();
@@ -48,9 +41,7 @@ fn zero_page_y() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 2;
     cpu.write(0x12, 0x4);
     cpu.init();
@@ -69,9 +60,7 @@ fn abs() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x1000, 0x4);
     cpu.init();
     cpu.exec();
@@ -89,9 +78,7 @@ fn abs_y() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 2;
     cpu.write(0x1002, 0x4);
     cpu.init();

--- a/yane-core/src/cpu/tests/load_instructions/ldy_instruction.rs
+++ b/yane-core/src/cpu/tests/load_instructions/ldy_instruction.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn immediate() {
     let mut rom = [0u8; 0x7fff];
 
@@ -11,9 +8,7 @@ fn immediate() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     assert_eq!(cpu.registers.y, 0x10);
@@ -29,9 +24,7 @@ fn zero_page() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x10, 0x4);
     cpu.init();
     cpu.exec();
@@ -48,9 +41,7 @@ fn zero_page_x() {
     rom[1] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 2;
     cpu.write(0x12, 0x4);
     cpu.init();
@@ -69,9 +60,7 @@ fn abs() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x1000, 0x4);
     cpu.init();
     cpu.exec();
@@ -89,9 +78,7 @@ fn abs_x() {
     rom[2] = 0x10;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 2;
     cpu.write(0x1002, 0x4);
     cpu.init();

--- a/yane-core/src/cpu/tests/math_operations/adc_instruction.rs
+++ b/yane-core/src/cpu/tests/math_operations/adc_instruction.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-#[test]
+use crate::CPU;#[test]
 fn immediate() {
     let mut rom = [0u8; 0x7fff];
 
@@ -13,9 +10,8 @@ fn immediate() {
     rom[3] = 7;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     cpu.exec();
@@ -34,9 +30,7 @@ fn zeropage() {
     rom[3] = 61;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.write(60, 10);
     cpu.write(61, 7);
     cpu.init();
@@ -56,10 +50,7 @@ fn zeropage_x() {
     rom[2] = 0x75;
     rom[3] = 61;
 
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(61, 10);
     cpu.write(62, 7);
@@ -82,11 +73,7 @@ fn abs() {
     rom[3] = 0x6D;
     rom[4] = 0x11;
     rom[5] = 0x10;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.write(0x1010, 10);
     cpu.write(0x1011, 7);
     cpu.init();
@@ -107,11 +94,7 @@ fn abs_x() {
     rom[3] = 0x7D;
     rom[4] = 0x11;
     rom[5] = 0x10;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(0x1011, 10);
     cpu.write(0x1012, 7);
@@ -134,11 +117,7 @@ fn abs_y() {
     rom[3] = 0x79;
     rom[4] = 0x11;
     rom[5] = 0x10;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 1;
     cpu.write(0x1011, 10);
     cpu.write(0x1012, 7);
@@ -159,11 +138,7 @@ fn indirect_y() {
 
     rom[2] = 0x71;
     rom[3] = 0x11;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.y = 1;
     cpu.write(0x11, 0x11);
     cpu.write(0x12, 0x12);
@@ -186,11 +161,7 @@ fn indirect_x() {
 
     rom[2] = 0x61;
     rom[3] = 0x11;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.registers.x = 1;
     cpu.write(0x12, 0x11);
     cpu.write(0x13, 0x12);
@@ -212,11 +183,7 @@ fn overflow_is_on_when_overflows() {
     rom[1] = 0x7f;
     rom[2] = 0x69;
     rom[3] = 1;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     cpu.exec();
@@ -234,11 +201,7 @@ fn carry_is_on_when_wraps() {
     rom[1] = 0xFF;
     rom[2] = 0x69;
     rom[3] = 0xFF;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     cpu.exec();
@@ -256,11 +219,7 @@ fn adds_carry_to_sum() {
     rom[1] = 0xF0;
     rom[2] = 0x69;
     rom[3] = 2;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.registers.carry = true;
     cpu.init();
     cpu.exec();

--- a/yane-core/src/cpu/tests/stack.rs
+++ b/yane-core/src/cpu/tests/stack.rs
@@ -1,13 +1,9 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn push() {
     
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(vec![])));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+
+    let mut cpu = CPU::from_rom(&[]);
     cpu.push(10);
     assert_eq!(
         cpu.registers.stack_pointer, 0x23,
@@ -22,9 +18,7 @@ fn push() {
 
 #[test]
 fn pop() {
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(vec![])));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&[]);
     cpu.push(10);
 
     let value = cpu.pop();
@@ -46,11 +40,7 @@ fn pha() {
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x48;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.a = 10;
     cpu.exec();
@@ -60,15 +50,10 @@ fn pha() {
 #[test]
 fn pla() {
     let mut rom = [0u8; 0x7fff];
-
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x68;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.push(10);
     cpu.exec();
@@ -79,15 +64,10 @@ fn pla() {
 #[test]
 fn php() {
     let mut rom = [0u8; 0x7fff];
-
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x08;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.carry = true;
     cpu.exec();
@@ -97,15 +77,10 @@ fn php() {
 #[test]
 fn plp() {
     let mut rom = [0u8; 0x7fff];
-
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0x28;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.push(0b10100000);
     cpu.exec();

--- a/yane-core/src/cpu/tests/subroutines.rs
+++ b/yane-core/src/cpu/tests/subroutines.rs
@@ -1,7 +1,4 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn jsr() {
     let mut rom = [0u8; 0x7fff];
@@ -13,9 +10,7 @@ fn jsr() {
     rom[2] = 0x80;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     assert_eq!(cpu.registers.stack_pointer, 0x22);
@@ -36,11 +31,7 @@ fn rts() {
     rom[1] = 0x50;
     rom[2] = 0x80;
     rom[0x50] = 0x60;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.exec();
     cpu.exec();

--- a/yane-core/src/cpu/tests/transfer_instructions.rs
+++ b/yane-core/src/cpu/tests/transfer_instructions.rs
@@ -1,19 +1,11 @@
-use std::{rc::Rc, sync::{Arc, Mutex}};
-
-use crate::{CPU, cartridge::Cartridge, memory::Memory, ppu::PPU};
-
+use crate::CPU;
 #[test]
 fn tax() {
     let mut rom = [0u8; 0x7fff];
-
     rom[0x3FFC] = 0x00;
     rom[0x3FFD] = 0x80;
     rom[0] = 0xAA;
-
-
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+    let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.a = 10;
     cpu.exec();
@@ -29,9 +21,7 @@ fn txa() {
     rom[0] = 0x8A;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.x = 10;
     cpu.exec();
@@ -48,9 +38,7 @@ fn tay() {
     rom[0] = 0xA8;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.a = 10;
     cpu.exec();
@@ -67,9 +55,7 @@ fn tya() {
     rom[0] = 0x98;
 
 
-    let cartridge = Arc::new(Mutex::new(Cartridge::from_rom(rom.to_vec())));
-    let memory = Memory::new(cartridge.clone(), Arc::new(Mutex::new(PPU::new(cartridge.clone()))));
-    let mut cpu = CPU::new(Rc::new(memory));
+let mut cpu = CPU::from_rom(&rom);
     cpu.init();
     cpu.registers.y = 10;
     cpu.exec();

--- a/yane-core/src/lib.rs
+++ b/yane-core/src/lib.rs
@@ -8,3 +8,5 @@ pub use cpu::CPU;
 pub use ppu::PPU;
 pub use cartridge::Cartridge;
 pub use memory::Memory;
+pub mod nes;
+pub use nes::NES;

--- a/yane-core/src/memory.rs
+++ b/yane-core/src/memory.rs
@@ -1,14 +1,14 @@
 use crate::cartridge::Cartridge;
 use crate::ppu::PPU;
-use std::{rc::Rc, sync::{Arc, Mutex}};
+use std::{rc::Rc, cell::RefCell};
 
 pub struct Memory {
     pub ram: [u8; 0x7ff],
-    cartridge: Arc<Mutex<Cartridge>>,
-    ppu: Arc<Mutex<PPU>>
+    cartridge: Rc<RefCell<Cartridge>>,
+    ppu: Rc<RefCell<PPU>>
 }
 impl Memory {
-    pub fn new(cartridge: Arc<Mutex<Cartridge>>, ppu: Arc<Mutex<PPU>>) -> Self {
+    pub fn new(cartridge: Rc<RefCell<Cartridge>>, ppu: Rc<RefCell<PPU>>) -> Self {
         Self {
             ram: [0; 0x7ff],
             cartridge,
@@ -16,8 +16,7 @@ impl Memory {
         }
     }
     pub fn cpu_write(&mut self, address: u16, data: u8) -> bool {
-        if self.cartridge.lock()
-            .unwrap()
+        if self.cartridge.borrow_mut()
             .cpu_write(address, data)
         {
             true
@@ -26,7 +25,7 @@ impl Memory {
             true
         } else if address <= 0x3fff && address >= 0x2000 {
             
-                self.ppu.lock().unwrap()
+                self.ppu.borrow_mut()
             .cpu_write(address & 0x7, data);
             true
         } else {
@@ -35,13 +34,13 @@ impl Memory {
         }
     }
     pub fn cpu_read(&mut self, address: u16) -> Option<u8> {
-        if let Some(value) = self.cartridge.lock().unwrap().cpu_read(address) {
+        if let Some(value) = self.cartridge.borrow_mut().cpu_read(address) {
             Some(value)
         } else if address < 0x2000 {
             Some(self.ram[(address & 0x7ff) as usize])
         } else if address <= 0x3fff && address >= 0x2000 {
             Some(
-                self.ppu.lock().unwrap()
+                self.ppu.borrow_mut()
             .cpu_read(address & 0x7))
         } else {
             eprintln!("ERROR: Reading Unmapped memory!");
@@ -50,16 +49,14 @@ impl Memory {
     }
     pub fn ppu_read(&self, address: u16) -> Option<u8> {
         if address < 0x1fff {
-            self.cartridge.lock().unwrap().ppu_read(address)
+            self.cartridge.borrow_mut().ppu_read(address)
         } else {
             None
         }
     }
     pub fn ppu_write(&mut self, address: u16, data: u8) -> bool {
         if address < 0x1fff {
-            self.cartridge.lock()
-                .unwrap()
-                .ppu_write(address, data)
+            self.cartridge.borrow_mut().ppu_write(address, data)
         } else {
             false
         }

--- a/yane-core/src/nes.rs
+++ b/yane-core/src/nes.rs
@@ -1,0 +1,53 @@
+use std::cell::Ref;
+use std::cell::RefCell;
+use std::cell::RefMut;
+use std::rc::Rc;
+use crate::{PPU, CPU, Cartridge, Memory};
+type Wrapped<T> = Rc<RefCell<T>>;
+macro_rules! getter {
+	($var:ident, $mut_var:ident, $type:ty) => {
+		pub fn $mut_var(&mut self) -> RefMut<$type> {
+			self.$var.borrow_mut()
+		}
+		pub fn $var(&self) -> Ref<$type> {
+			self.$var.borrow()
+		}
+	};
+}
+pub struct NES {
+	pub cpu: Wrapped<CPU>,
+	pub ppu: Wrapped<PPU>,
+	pub cartridge: Wrapped<Cartridge>,
+	pub memory: Wrapped<Memory>,
+	clock_count: u8
+}
+impl NES {
+	getter!(memory, mut_memory, Memory);
+	getter!(ppu, mut_ppu, PPU);
+	getter!(cartridge, mut_cartridge, Cartridge);
+	getter!(cpu, mut_cpu, CPU);
+	pub fn clock(&mut self){
+		self.mut_ppu().run();
+		if self.clock_count % 3 == 0 {
+			self.mut_cpu().clock();
+		}
+		self.clock_count += 1;
+	}
+	pub fn new(cartridge: Cartridge) -> Self {
+		let cartridge = wrap(cartridge);
+		let ppu = wrap(PPU::new(cartridge.clone()));
+		let memory = wrap(Memory::new(cartridge.clone(), ppu.clone()));
+		let mut cpu = CPU::new(memory.clone());
+		cpu.init();
+		Self {
+			cartridge,
+			ppu,
+			memory,
+			cpu: wrap(cpu),
+			clock_count: 0,
+		}
+	}
+}
+fn wrap<T>(v: T) -> Wrapped<T> {
+	return Rc::new(RefCell::new(v));
+}

--- a/yane-web/src/lib.rs
+++ b/yane-web/src/lib.rs
@@ -26,21 +26,15 @@ pub fn start(){
         .unwrap()
         .dyn_into::<web_sys::CanvasRenderingContext2d>()
         .unwrap();
-    let cartridge = Arc::new(Mutex::new(get_cartridge()));
-    let ppu = Arc::new(Mutex::new(PPU::new(cartridge.clone())));
-    let memory = Memory::new(cartridge.clone(), ppu.clone());
-    let mut cpu = CPU::new(Rc::new(memory));
-    let mut clock_counter = 0;
-    cpu.init();
+    let mut nes = NES::new(get_cartridge());
     log("Everything's working, Everything's twerking.");
     let f = Rc::new(RefCell::new(None));
     let g = f.clone();
     *g.borrow_mut() = Some(Closure::new(move || {
-
-        clock_counter = clock(clock_counter, &mut cpu, ppu.clone());
+        nes.clock();
         context.set_fill_style(&"#FFFFFF".into());
         context.fill_rect(0.0, 0.0, 256.0, 240.0);
-        let ppu = ppu.lock().unwrap();
+        let ppu = nes.ppu();
         draw_chr_memory(&context, 0, 1, 0, 0, &ppu);
         draw_chr_memory(&context, 1, 1, 0, 128, &ppu);
         request_animation_frame(f.borrow().as_ref().unwrap());

--- a/yane-web/src/lib.rs
+++ b/yane-web/src/lib.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::f64;
-use std::time::Instant;
 use std::{rc::Rc, sync::*};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;


### PR DESCRIPTION
The emulator initialization was pretty verbose, you needed to initialize any and every component of the NES, and this created a lot of copy and pasting in the tests.